### PR TITLE
添加第一页脚注和数组部分

### DIFF
--- a/advance/collections.lyx
+++ b/advance/collections.lyx
@@ -124,8 +124,9 @@ name "chap:集合类"
 \end_layout
 
 \begin_layout Standard
-“集合”是我们现实生活中经常遇到的数据表达方式，比如通讯录（记录了姓名、电话号码、住址等）、字典（记录了文字和其意义的对照关系）等等。为了更好的表达和处理集合，
-Java提供了集合类框架（Collections Framework），包括以下三个部分：
+“集合”是我们现实生活中经常遇到的数据表达方式，比如通讯录（记录了姓名、电话号码、住址等）、字典（记录了文字和其意义的对照关系）等等。当然我们可以使用数组来保存
+多个对象,但是数组长度不可变化,一旦在初始状态制定了数组长度,这个数组长度就是固定不可变的,如果想保存数量变化的数据,数组就有点无能为力了.为了这种数量不确定的数
+据,以及保存具有映射关系的数据(也成为关系数组)，Java提供了集合类框架（Collections Framework），包括以下三个部分：
 \end_layout
 
 \begin_layout Itemize
@@ -254,8 +255,18 @@ name "fig:集合类框架的接口"
 
 \begin_layout Standard
 所有集合类框架中的接口和类都是泛型化的。实际上，Java泛型的提出最初的目的就是为了增强集合类框架
-\begin_inset Note Note
+\begin_inset Foot
 status open
+
+\begin_layout Plain Layout
+IBM文档库:http://www.ibm.com/developerworks/cn/java/j-jtp01255.html
+\end_layout
+
+\end_inset
+
+
+\begin_inset Note Note
+status collapsed
 
 \begin_layout Plain Layout
 此说法从何而来？需要文献索引


### PR DESCRIPTION
在集合类介绍部分添加数组和集合类的比较,页脚加上(Java泛型的提出最初的目的就是为了增强集合类框架)的来源